### PR TITLE
include content rating (other than “safe”) as a tag for MangaDex

### DIFF
--- a/src/MangaDex/MangaDex.ts
+++ b/src/MangaDex/MangaDex.ts
@@ -70,7 +70,7 @@ export const MangaDexInfo: SourceInfo = {
     description: 'Extension that pulls manga from MangaDex',
     icon: 'icon.png',
     name: 'MangaDex',
-    version: '2.1.8',
+    version: '2.1.9',
     authorWebsite: 'https://github.com/nar1n',
     websiteBaseURL: MANGADEX_DOMAIN,
     contentRating: ContentRating.EVERYONE,

--- a/src/MangaDex/MangaDex.ts
+++ b/src/MangaDex/MangaDex.ts
@@ -265,6 +265,13 @@ export class MangaDex extends Source {
             status = MangaStatus.ONGOING
         }
         const tags: Tag[] = []
+        const contentRating: string = mangaDetails.contentRating
+         if(contentRating && contentRating != 'safe') {
+             tags.push(createTag({
+                 id: contentRating,
+                 label: contentRating.charAt(0).toUpperCase() + contentRating.substring(1)
+             }))
+         }
         for (const tag of mangaDetails.tags) {
             const tagName: {[index: string]: string} = tag.attributes.name
             tags.push(createTag({


### PR DESCRIPTION
I have seen this requested before, and I had done this in the fork I maintain for personal use, so I figured I might as well offer the improvement to the main fork.