### PR TITLE
Webtoons: Updated Functionality for Canvas Comics

### DIFF
--- a/src/Webtoons/Webtoons.ts
+++ b/src/Webtoons/Webtoons.ts
@@ -138,8 +138,10 @@ export class Webtoons extends Source {
         let tagSearch
 
         if (query.title) {
+            const searchType = query?.includedTags?.map((x: any) => x.id)[0] ?? 'WEBTOON' // Search will return "Canvas" titles or "Original" titles. Original is default. Cannot return both.
+            tagSearch = searchType
             request = createRequestObject({
-                url: `${WEBTOONS_DOMAIN}/${lang[0]}/search?keyword=${(query.title ?? '').replace(/ /g, '+')}&page=${page}`,
+                url: `${WEBTOONS_DOMAIN}/${lang[0]}/search?keyword=${(query.title ?? '').replace(/ /g, '+')}&searchType=${searchType}&page=${page}`,
                 method: 'GET'
             })
 
@@ -149,7 +151,6 @@ export class Webtoons extends Source {
                 type = 'tag'
                 tagSearch = hasTag
             }
-
             request = createRequestObject({
                 url: `${WEBTOONS_DOMAIN}/${lang[0]}/genre`,
                 method: 'GET'

--- a/src/Webtoons/Webtoons.ts
+++ b/src/Webtoons/Webtoons.ts
@@ -28,7 +28,7 @@ const userAgent = 'Mozilla/5.0 (iPhone; CPU iPhone OS 15_4_1 like Mac OS X) Appl
 let langString = 'en' // Only used for 'getMangaShareUrl' function
 
 export const WebtoonsInfo: SourceInfo = {
-    version: '2.0.0',
+    version: '2.1.0',
     name: 'Webtoons',
     description: 'Extension that pulls comics from Webtoons.',
     author: 'btylerh7',

--- a/src/Webtoons/WebtoonsParser.ts
+++ b/src/Webtoons/WebtoonsParser.ts
@@ -18,7 +18,7 @@ export class Parser {
     parseMangaDetails($: CheerioStatic, mangaId: string): Manga {
         const title = $('.subj').text().split('\n')[0]?.trim() ?? ''
         const desc = $('p.summary').text().trim() ?? ''
-        const image = $('.background_pic').find('img').attr('src') ?? ''
+        const image = $('.background_pic').find('img').attr('src') ?? $('.detail_chal_pic').find('img').attr('src') 
         const rating = Number($('em.grade_num').text().replace(',', '.').trim()) ?? 0
         const status = MangaStatus.ONGOING
         const author = $('.author').text().trim().split(/\r?\n/)[0]?.trim()
@@ -32,7 +32,7 @@ export class Parser {
         return createManga({
             id: mangaId,
             titles: [this.decodeHTMLEntity(title)],
-            image,
+            image: image ?? '',
             author,
             rating,
             status,

--- a/src/Webtoons/WebtoonsParser.ts
+++ b/src/Webtoons/WebtoonsParser.ts
@@ -109,12 +109,13 @@ export class Parser {
         const results: MangaTile[] = []
 
         if (type == 'title') {
-            for (const result of $('.card_lst').find('li').toArray()) {
+            const resultUl = tagSearch == 'CHALLENGE' ? '.challenge_lst.search' : '.card_lst'
+            for (const result of $(resultUl).find('li').toArray()) {
                 const genre = $(result).find('span').text().toLowerCase().replace('like', '').trim()
                 const title = $(result).find('.subj').text().trim()
                 const urlTitle = title.replace(/-|'/g, '').replace(/ /g, '-').toLowerCase()
                 const idNumber = $(result).find('a').attr('href')?.split('titleNo=')[1]
-                const id = `${genre}/${urlTitle}/list?title_no=${idNumber}`
+                const id = `${tagSearch = 'CHALLENGE' ? 'challenge' : genre}/${urlTitle}/list?title_no=${idNumber}`
                 const subtitle = $(result).find('.author').text().trim() ?? ''
 
                 if (!id || !title) continue
@@ -310,7 +311,14 @@ export class Parser {
 
             genres.push(createTag({ label: label, id: id }))
         }
-        return [createTagSection({ id: '0', label: 'genres', tags: genres })]
+        // Allows for users to search for Original or Canvas comics. Cannot search for both.
+        const searchType: Tag[] = [
+            createTag({label: 'Canvas', id:'CHALLENGE'}),
+            createTag({label: 'Original',id:'WEBTOON'})
+        ]
+        const genresSection = createTagSection({ id: '0', label: 'genres', tags: genres })
+        const searchTypeSection = createTagSection({ id: '1', label: 'search-type', tags: searchType})
+        return [genresSection, searchTypeSection]
     }
 
     protected decodeHTMLEntity(str: string): string {


### PR DESCRIPTION
I noticed that the source does not have as much support for the Canvas comics, as they are often separated from search result pages and genre pages. So I added the following features:

## Manga Details Page
- The selector for the image is different, so I added that.
## Get Tags
- Added a tag section (in the parser function) to allow searching "Original" or "Canvas" Comics
## Search Results
- Added the option to search for "Original" or "Canvas" comics. Not sure if the formatting is the cleanest, so if you have any suggestions, feel free to make it look neater!
- The default is for only Originals if the search tag for Canvas is not set. It would be just like it was before.
- There is **no** way to search both Canvas and Originals at the same time, and I also have not added the ability to search Canvas and another Tag. It will just ignore the "Canvas" section if there is no `query.title`.